### PR TITLE
readme: fix link to codecov

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Gollum
 **A Swift A/B testing framework for iOS**
 
-[![Build Status](https://travis-ci.org/eduardoeof/Gollum.svg?branch=master)](https://travis-ci.org/eduardoeof/Gollum) [![codecov.io](http://codecov.io/gh/eduardoeof/Gollum/coverage.svg?branch=master)](http://codecov.io/gh/eduardoeof/Gollum/coverage.svg?branch=master) [![Code Climate](https://codeclimate.com/github/eduardoeof/Gollum/badges/gpa.svg)](https://codeclimate.com/github/eduardoeof/Gollum)
+[![Build Status](https://travis-ci.org/eduardoeof/Gollum.svg?branch=master)](https://travis-ci.org/eduardoeof/Gollum)
+[![codecov.io](http://codecov.io/gh/eduardoeof/Gollum/coverage.svg?branch=master)](http://codecov.io/gh/eduardoeof/Gollum)
+[![Code Climate](https://codeclimate.com/github/eduardoeof/Gollum/badges/gpa.svg)](https://codeclimate.com/github/eduardoeof/Gollum)
 
 
 A/B testing (also known as split testing) is a good practice to test new concepts. Gollum is a A/B testing framework easy to use and inspired on some best practices in Swift, like:


### PR DESCRIPTION
Link to Codecov was wrong, pointing to its own badge. 
Changed to http://codecov.io/gh/eduardoeof/Gollum

Also added break lines between the lines you put the badges, so it's easier to see while editing. The rendered result is still the same.
